### PR TITLE
Optimized IFileType creation

### DIFF
--- a/FileTypeChecker.Web/IFormFileExtensions.cs
+++ b/FileTypeChecker.Web/IFormFileExtensions.cs
@@ -1,10 +1,8 @@
 ﻿namespace FileTypeChecker.Web
 {
     using FileTypeChecker.Abstracts;
-    using FileTypeChecker.Common;
     using FileTypeChecker.Extensions;
     using Microsoft.AspNetCore.Http;
-    using System;
     using System.IO;
 
     public static class IFormFileExtensions
@@ -15,12 +13,9 @@
         /// <typeparam name="T">Type that implements FileType</typeparam>
         /// <param name="formFile"></param>
         /// <returns>True if file match the desired type otherwise returns false.</returns>
-        public static bool Is<T>(this IFormFile formFile) where T : FileType, IFileType
+        public static bool Is<T>(this IFormFile formFile) where T : FileType, IFileType, new()
         {
-            var instance = Activator.CreateInstance(typeof(T)) as FileType;
-
-            DataValidator.ThrowIfNull(instance, nameof(FileType));
-
+            var instance = new T();
             return instance.DoesMatchWith(formFile.ReadFileAsStream());
         }
         /// <summary>

--- a/FileTypeChecker.Web/IFormFileTypeValidator.cs
+++ b/FileTypeChecker.Web/IFormFileTypeValidator.cs
@@ -76,7 +76,7 @@
         /// <typeparam name="T">Type that implements FileType</typeparam>
         /// <param name="formFile">Object that implements IFormFile interface.</param>
         /// <returns>True if file match the desired type otherwise returns false.</returns>
-        public static bool Is<T>(IFormFile formFile) where T : FileType, IFileType
+        public static bool Is<T>(IFormFile formFile) where T : FileType, IFileType, new()
             => formFile.ReadFileAsStream().Is<T>();
         /// <summary>
         /// Validates that the current file is image.

--- a/FileTypeChecker/Extensions/StreamExtensions.cs
+++ b/FileTypeChecker/Extensions/StreamExtensions.cs
@@ -1,9 +1,7 @@
 ﻿namespace FileTypeChecker.Extensions
 {
     using FileTypeChecker.Abstracts;
-    using FileTypeChecker.Common;
     using FileTypeChecker.Types;
-    using System;
     using System.IO;
 
     public static class StreamExtensions
@@ -14,14 +12,12 @@
         /// <typeparam name="T">Type that implements FileType</typeparam>
         /// <param name="fileContent">File as stream</param>
         /// <returns>True if file match the desired type otherwise returns false.</returns>
-        public static bool Is<T>(this Stream fileContent) where T : FileType, IFileType
+        public static bool Is<T>(this Stream fileContent) where T : FileType, IFileType, new()
         {
-            var instance = Activator.CreateInstance(typeof(T)) as FileType;
-
-            DataValidator.ThrowIfNull(instance, nameof(FileType));
-
+            var instance = new T();
             return instance.DoesMatchWith(fileContent);
         }
+
         /// <summary>
         /// Validates that the current file is image.
         /// </summary>


### PR DESCRIPTION
Optimized use of `Activator.CreateInstance` since this is generally slow. By adding `new()` to the generic requirements, we can easily create an instance. No downside since the activator will fail to create a non-empty constructor anyway. This way we get a compile time error instead of run-time, win-win! (Besides perfo improvements)

 Also made a small improvement in how `RegisterTypes` works, since it was possible to call this method after initialization thus resulting in multiple IFileType instances of the same type.