### PR TITLE
Adds Null-conditional operator to Is<T> extension check

### DIFF
--- a/FileTypeChecker.Tests/StreamExtensionsTests.cs
+++ b/FileTypeChecker.Tests/StreamExtensionsTests.cs
@@ -107,5 +107,15 @@
 
             Assert.AreEqual(expected, actual);
         }
+
+        [Test]
+        public void Is_ShouldReturnFalseIfRandomInput()
+        {
+            using var memorystream = new MemoryStream(new byte[] {4, 6, 210, 16, 48, 31, 48, 45});
+            var expected = false;
+            var actual = memorystream.Is<Gzip>();
+
+            Assert.AreEqual(expected, actual);
+        }
     }
 }

--- a/FileTypeChecker/Extensions/StreamExtensions.cs
+++ b/FileTypeChecker/Extensions/StreamExtensions.cs
@@ -17,7 +17,7 @@
             var instance = new T();
             var match = FileTypeValidator.GetBestMatch(fileContent);
 
-            return match.GetType() == instance.GetType();
+            return match?.GetType() == instance.GetType();
         }
 
         /// <summary>


### PR DESCRIPTION
There was a NullReferenceException in case an unknonw or invalid file was checked using Is<T>.
This fixes the issue and adds a UnitTest that can catch it. 