### PR TITLE
Added dynamically assessed MinimalBufferSize to allow validation with custom validators requiring more than 20 bytes

### DIFF
--- a/FileTypeChecker.Tests/FileTypeChecker.Tests.csproj
+++ b/FileTypeChecker.Tests/FileTypeChecker.Tests.csproj
@@ -28,6 +28,12 @@
     <None Update="files\365-test.docx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="files\arbitrary_csv_1.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="files\arbitrary_csv_2.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Files\blob.mp3">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/FileTypeChecker.Tests/Setup.cs
+++ b/FileTypeChecker.Tests/Setup.cs
@@ -1,0 +1,28 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FileTypeChecker.Tests
+{
+    [SetUpFixture]
+    public class Setup
+    {
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            FileTypeValidator.RegisterCustomTypes(Assembly.GetAssembly(typeof(FileTypeValidatorTests)));
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+        }
+
+
+    }
+}

--- a/FileTypeChecker.Tests/files/arbitrary_csv_1.txt
+++ b/FileTypeChecker.Tests/files/arbitrary_csv_1.txt
@@ -1,0 +1,5 @@
+ID;field_1;field_2;field_3;field_4;field_5;field_6;field_7;field_8
+1;field_1;field_2;field_3;field_4;field_5;field_6;field_7;field_8
+2;field_1;field_2;field_3;field_4;field_5;field_6;field_7;field_8
+3;field_1;field_2;field_3;field_4;field_5;field_6;field_7;field_8
+4;field_1;field_2;field_3;field_4;field_5;field_6;field_7;field_8

--- a/FileTypeChecker.Tests/files/arbitrary_csv_2.txt
+++ b/FileTypeChecker.Tests/files/arbitrary_csv_2.txt
@@ -1,0 +1,5 @@
+ID;field_1;field_2;field_3;field_4;field_5;field_6;field_7;field_8;field_9
+1;field_1;field_2;field_3;field_4;field_5;field_6;field_7;field_8;field_9
+2;field_1;field_2;field_3;field_4;field_5;field_6;field_7;field_8;field_9
+3;field_1;field_2;field_3;field_4;field_5;field_6;field_7;field_8;field_9
+4;field_1;field_2;field_3;field_4;field_5;field_6;field_7;field_8;field_9

--- a/FileTypeChecker/Abstracts/FileType.cs
+++ b/FileTypeChecker/Abstracts/FileType.cs
@@ -10,7 +10,8 @@
 
     public abstract class FileType : IFileType
     {
-        private static int BufferDefaultSize => Math.Max( FileTypeValidator.MinimalBufferSize, 20);
+
+        private int BufferSize => Math.Max( MaxMagicSequenceLength, 20);
         private string _name;
         private string _extension;
         private MagicSequence[] _bytes;
@@ -87,7 +88,7 @@
             if (stream.Position != 0 && resetPosition) 
                 stream.Position = 0;
 
-            var buffer = new byte[BufferDefaultSize];
+            var buffer = new byte[BufferSize];
             stream.Read(buffer, 0, buffer.Length);
 
             return CompareBytes(buffer);
@@ -110,7 +111,7 @@
             if (stream.Position != 0 && resetPosition) 
                 stream.Position = 0;
 
-            var buffer = new byte[BufferDefaultSize];
+            var buffer = new byte[BufferSize];
             await stream.ReadAsync(buffer, 0, buffer.Length);
 
             return CompareBytes(buffer);
@@ -118,7 +119,7 @@
 
         public int GetMatchingNumber(Stream stream)
         {
-            var buffer = new byte[BufferDefaultSize];
+            var buffer = new byte[BufferSize];
             stream.Position = 0;
             stream.Read(buffer, 0, buffer.Length);
 

--- a/FileTypeChecker/Abstracts/FileType.cs
+++ b/FileTypeChecker/Abstracts/FileType.cs
@@ -10,7 +10,7 @@
 
     public abstract class FileType : IFileType
     {
-        private const int BufferDefaultSize = 20;
+        private static int BufferDefaultSize => Math.Max( FileTypeValidator.MinimalBufferSize, 20);
         private string _name;
         private string _extension;
         private MagicSequence[] _bytes;
@@ -72,6 +72,9 @@
                 this._bytes = value;
             }
         }
+
+        /// <inheritdoc />
+        public int MaxMagicSequenceLength => Bytes.Max(o => o.Length);
 
         /// <inheritdoc />
         public bool DoesMatchWith(Stream stream, bool resetPosition = true)

--- a/FileTypeChecker/Abstracts/IFileType.cs
+++ b/FileTypeChecker/Abstracts/IFileType.cs
@@ -14,7 +14,12 @@
         /// Returns the extension of the current <see cref="IFileType"/> without dot.
         /// </summary>
         string Extension { get; }
-        
+
+        /// <summary>
+        /// Returns the max length of all the magic sequences added to the <see cref="FileType"/>.
+        /// </summary>
+        int MaxMagicSequenceLength { get; }
+
         /// <summary>
         /// Checks if current <see cref="IFileType"/> matches with file from stream.
         /// </summary>

--- a/FileTypeChecker/FileTypeValidator.cs
+++ b/FileTypeChecker/FileTypeValidator.cs
@@ -26,6 +26,11 @@ namespace FileTypeChecker
         private static readonly HashSet<Type> KnownTypes = new();
         private static readonly List<IFileType> FileTypes = new();
 
+        /// <summary>
+        /// The minimal buffer size required to validate all the known <see cref="FileType"/>s.
+        /// </summary>
+        internal static int MinimalBufferSize { private set; get; }
+
         private static IReadOnlyCollection<IFileType> Types
         {
             get
@@ -241,6 +246,7 @@ namespace FileTypeChecker
                     }
                 }
             }
+            MinimalBufferSize = FileTypes.Max(o => o.MaxMagicSequenceLength);
         }
 
         private static IFileType FindBestMatch(Stream fileContent, IList<IFileType> result)

--- a/FileTypeChecker/FileTypeValidator.cs
+++ b/FileTypeChecker/FileTypeValidator.cs
@@ -26,11 +26,6 @@ namespace FileTypeChecker
         private static readonly HashSet<Type> KnownTypes = new();
         private static readonly List<IFileType> FileTypes = new();
 
-        /// <summary>
-        /// The minimal buffer size required to validate all the known <see cref="FileType"/>s.
-        /// </summary>
-        internal static int MinimalBufferSize { private set; get; }
-
         private static IReadOnlyCollection<IFileType> Types
         {
             get
@@ -246,7 +241,6 @@ namespace FileTypeChecker
                     }
                 }
             }
-            MinimalBufferSize = FileTypes.Max(o => o.MaxMagicSequenceLength);
         }
 
         private static IFileType FindBestMatch(Stream fileContent, IList<IFileType> result)

--- a/FileTypeChecker/MagicSequence.cs
+++ b/FileTypeChecker/MagicSequence.cs
@@ -13,6 +13,8 @@
         private readonly int _bytesToSkip;
         private readonly int _indexToStart;
 
+        public int Length => _data.Length;
+
         public MagicSequence(byte[] data, int offset) : this(data, offset, 0)
         { }
 


### PR DESCRIPTION
Hello @AJMitev 

I'm using your library in many projects with custom validators.

In a particular case I have to validate / recognize a couple of CSV files and I would like to stick to the "Use FileTypeChecker" pattern. The problem with this approach is that the BufferDefaultSize is fixed to 20 bytes, which in many cases is below the threshold I need to accurately determine the file type.

So I modified it to be dynamically determined, based on the size of the largest MagicSequence defined for the FileType being checked. Since BufferDefaultSize wasn't a fitting name anymore I renamed it to BufferSize, making it a getter.

I also added an appropriate test (GetFileType_ShouldUseTheMinimalBufferSizeWhenUsingStream).

Thank you very much for your time and effort, best regards

Daniele (ziocampo)