### PR TITLE
Fix tests on case-sensitive filesystems (Files -> files)

### DIFF
--- a/FileTypeChecker.Tests/FileTypeChecker.Tests.csproj
+++ b/FileTypeChecker.Tests/FileTypeChecker.Tests.csproj
@@ -20,10 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="Files\365-doc.docx">
+    <None Update="files\365-doc.docx">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="Files\365-excel.xlsx">
+    <None Update="files\365-excel.xlsx">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="files\365-test.docx">
@@ -35,7 +35,7 @@
     <None Update="files\arbitrary_csv_2.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="Files\blob.mp3">
+    <None Update="files\blob.mp3">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="files\sample.heic">
@@ -44,70 +44,70 @@
     <None Update="files\FileTypeCheckerLogo-150.heic">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="Files\test-bom.xml">
+    <None Update="files\test-bom.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="Files\test">
+    <None Update="files\test">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="Files\test.7z">
+    <None Update="files\test.7z">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="Files\test.bmp">
+    <None Update="files\test.bmp">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="Files\test.csv">
+    <None Update="files\test.csv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="Files\test.doc">
+    <None Update="files\test.doc">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="Files\test.exe">
+    <None Update="files\test.exe">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="Files\test.gif">
+    <None Update="files\test.gif">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="Files\test.ico">
+    <None Update="files\test.ico">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="Files\test.jpg">
+    <None Update="files\test.jpg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="files\test.mpo">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="Files\test.pdf">
+    <None Update="files\test.pdf">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="Files\test.png">
+    <None Update="files\test.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="Files\test.psd">
+    <None Update="files\test.psd">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="Files\test.tif">
+    <None Update="files\test.tif">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="files\test.webp">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="Files\test.wmf">
+    <None Update="files\test.wmf">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="Files\test.xml">
+    <None Update="files\test.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="Files\test.zip">
+    <None Update="files\test.zip">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="Files\test.gz">
+    <None Update="files\test.gz">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="Files\test.bz2">
+    <None Update="files\test.bz2">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="Files\test.mp4">
+    <None Update="files\test.mp4">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="files\testwin10.zip">

--- a/FileTypeChecker.Tests/FileTypeValidatorReadOnlySpanTests.cs
+++ b/FileTypeChecker.Tests/FileTypeValidatorReadOnlySpanTests.cs
@@ -9,7 +9,7 @@ namespace FileTypeChecker.Tests
     [TestFixture]
     public class FileTypeValidatorReadOnlySpanTests
     {
-        private static readonly string FilesPath = Path.Combine(Directory.GetCurrentDirectory(), "Files");
+        private static readonly string FilesPath = Path.Combine(Directory.GetCurrentDirectory(), "files");
 
         [Test]
         [TestCase("test.bmp", true)]


### PR DESCRIPTION
Fixes #51.

The test fixture directory on disk is `files`, but `FileTypeValidatorReadOnlySpanTests` and several `<None Update="Files\…">` entries in the test csproj reference it as `Files`. On case-insensitive filesystems that's harmless; on Linux the capital-`Files` items copy into a separate output folder and 34 ReadOnlySpan tests fail with `DirectoryNotFoundException`.

This normalises every reference to the on-disk lowercase `files`: the `FilesPath` constant in the test and the `<None Update>` entries in `FileTypeChecker.Tests.csproj`. No production code changes.