### PR TITLE
Detect PDFs when the %PDF- header is within the first 1024 bytes

### DIFF
--- a/FileTypeChecker.Tests/Types/PortableDocumentFormatTests.cs
+++ b/FileTypeChecker.Tests/Types/PortableDocumentFormatTests.cs
@@ -1,0 +1,98 @@
+namespace FileTypeChecker.Tests.Types
+{
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using FileTypeChecker.Types;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class PortableDocumentFormatTests
+    {
+        private static readonly byte[] PdfHeader = { 0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x34 }; // "%PDF-1.4"
+
+        private static MemoryStream BuildStream(int leadingJunk, int trailing)
+        {
+            var buffer = new byte[leadingJunk + PdfHeader.Length + trailing];
+            for (var i = 0; i < leadingJunk; i++)
+            {
+                buffer[i] = 0xAA;
+            }
+
+            PdfHeader.CopyTo(buffer, leadingJunk);
+            return new MemoryStream(buffer);
+        }
+
+        [Test]
+        public void DoesMatchWith_ShouldReturnTrue_WhenMagicAtOffsetZero()
+        {
+            var subject = new PortableDocumentFormat();
+            using var stream = BuildStream(leadingJunk: 0, trailing: 64);
+
+            Assert.IsTrue(subject.DoesMatchWith(stream));
+        }
+
+        [Test]
+        public void DoesMatchWith_ShouldReturnTrue_WhenMagicAppearsLaterWithinFirst1024Bytes()
+        {
+            var subject = new PortableDocumentFormat();
+            using var stream = BuildStream(leadingJunk: 240, trailing: 256);
+
+            Assert.IsTrue(subject.DoesMatchWith(stream));
+        }
+
+        [Test]
+        public void DoesMatchWith_ShouldReturnTrue_WhenMagicEndsExactlyAtByte1024()
+        {
+            var subject = new PortableDocumentFormat();
+            using var stream = BuildStream(leadingJunk: 1024 - PdfHeader.Length, trailing: 0);
+
+            Assert.IsTrue(subject.DoesMatchWith(stream));
+        }
+
+        [Test]
+        public void DoesMatchWith_ShouldReturnFalse_WhenMagicStartsBeyondFirst1024Bytes()
+        {
+            var subject = new PortableDocumentFormat();
+            using var stream = BuildStream(leadingJunk: 1100, trailing: 64);
+
+            Assert.IsFalse(subject.DoesMatchWith(stream));
+        }
+
+        [Test]
+        public void DoesMatchWith_ShouldReturnFalse_WhenMagicIsAbsent()
+        {
+            var subject = new PortableDocumentFormat();
+            using var stream = new MemoryStream(Enumerable.Repeat((byte)0xAA, 2048).ToArray());
+
+            Assert.IsFalse(subject.DoesMatchWith(stream));
+        }
+
+        [Test]
+        public void GetFileType_ShouldClassifyAsPdf_WhenMagicIsWrappedInAMultipartEnvelope()
+        {
+            using var stream = BuildMultipartEnvelope();
+
+            var detected = FileTypeValidator.GetFileType(stream);
+
+            Assert.AreEqual(PortableDocumentFormat.TypeName, detected.Name);
+        }
+
+        private static MemoryStream BuildMultipartEnvelope()
+        {
+            const string boundary = "181fee63-5203-4ea2-90a1-75747423b2db";
+            const string pdfBody = "%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\nstartxref\n0\n%%EOF";
+
+            var envelope = new StringBuilder()
+                .Append("--").Append(boundary).Append("\r\n")
+                .Append("Content-Disposition: form-data; name=File; filename=report.pdf\r\n")
+                .Append("\r\n")
+                .Append(pdfBody)
+                .Append("\r\n")
+                .Append("--").Append(boundary).Append("--\r\n")
+                .ToString();
+
+            return new MemoryStream(Encoding.ASCII.GetBytes(envelope));
+        }
+    }
+}

--- a/FileTypeChecker/Abstracts/FileType.cs
+++ b/FileTypeChecker/Abstracts/FileType.cs
@@ -93,7 +93,7 @@
         public int MaxMagicSequenceLength => Bytes.Max(o => o.Length);
 
         /// <inheritdoc />
-        public bool DoesMatchWith(Stream stream, bool resetPosition = true)
+        public virtual bool DoesMatchWith(Stream stream, bool resetPosition = true)
         {
             DataValidator.ThrowIfNull(stream, nameof(Stream));
 
@@ -109,7 +109,7 @@
             return CompareBytes(buffer);
         }
 
-        public bool DoesMatchWith(byte[] bytes)
+        public virtual bool DoesMatchWith(byte[] bytes)
         {
             DataValidator.ThrowIfNull(bytes, nameof(Array));
 
@@ -156,7 +156,7 @@
         // High-performance ReadOnlySpan<byte> overloads
 
         /// <inheritdoc />
-        public bool DoesMatchWith(ReadOnlySpan<byte> bytes) => CompareBytes(bytes);
+        public virtual bool DoesMatchWith(ReadOnlySpan<byte> bytes) => CompareBytes(bytes);
 
         /// <inheritdoc />
         public int GetMatchingNumber(ReadOnlySpan<byte> bytes) 

--- a/FileTypeChecker/Types/PortableDocumentFormat.cs
+++ b/FileTypeChecker/Types/PortableDocumentFormat.cs
@@ -1,16 +1,73 @@
-﻿namespace FileTypeChecker.Types
+namespace FileTypeChecker.Types
 {
+    using System;
+    using System.IO;
     using Abstracts;
+    using Common;
+    using Exceptions;
 
     public class PortableDocumentFormat : FileType, IFileType
     {
         public const string TypeName = "Portable Document Format";
         public const string TypeMimeType = "application/pdf";
         public const string TypeExtension = "pdf";
+
+        /// <summary>
+        /// The PDF specification permits the "%PDF-" header to appear anywhere
+        /// within the first 1024 bytes rather than strictly at offset 0 (for
+        /// example when the document is wrapped in a MIME multipart envelope),
+        /// so the header is searched for across that window instead of anchored
+        /// to the start of the stream.
+        /// </summary>
+        private const int HeaderSearchWindow = 1024;
+
         private static readonly byte[] MagicBytes = { 0x25, 0x50, 0x44, 0x46, 0x2D };
 
         public PortableDocumentFormat() : base(TypeName, TypeMimeType, TypeExtension, MagicBytes)
         {
+        }
+
+        public override bool DoesMatchWith(Stream stream, bool resetPosition = true)
+        {
+            DataValidator.ThrowIfNull(stream, nameof(Stream));
+
+            if (!stream.CanRead || (stream.Position != 0 && !stream.CanSeek))
+                throw new StreamMustBeReadableException();
+
+            if (stream.Position != 0 && resetPosition)
+                stream.Position = 0;
+
+            var buffer = new byte[HeaderSearchWindow];
+            var read = FillBuffer(stream, buffer);
+
+            return DoesMatchWith(buffer.AsSpan(0, read));
+        }
+
+        public override bool DoesMatchWith(byte[] bytes)
+        {
+            DataValidator.ThrowIfNull(bytes, nameof(Array));
+
+            return DoesMatchWith((ReadOnlySpan<byte>)bytes);
+        }
+
+        public override bool DoesMatchWith(ReadOnlySpan<byte> bytes)
+        {
+            var windowLength = Math.Min(bytes.Length, HeaderSearchWindow);
+
+            return bytes.Slice(0, windowLength).IndexOf(MagicBytes.AsSpan()) >= 0;
+        }
+
+        private static int FillBuffer(Stream stream, byte[] buffer)
+        {
+            var total = 0;
+            int read;
+            while (total < buffer.Length &&
+                   (read = stream.Read(buffer, total, buffer.Length - total)) > 0)
+            {
+                total += read;
+            }
+
+            return total;
         }
     }
 }


### PR DESCRIPTION
Fixes #52.

`PortableDocumentFormat` only matched `%PDF-` at offset 0, so PDFs with bytes before the header (e.g. saved inside a `multipart/form-data` body) were reported as unrecognised — even though Acrobat and the PDF reference's implementation notes accept the header anywhere in the first 1024 bytes.

This makes the `DoesMatchWith` overloads on `FileType` `virtual` and overrides them in `PortableDocumentFormat` to search the first 1024 bytes for the signature. All other file types stay anchored at offset 0.

Adds `PortableDocumentFormatTests` covering offset 0, a later offset within the window, the header ending exactly at byte 1024, a header beyond 1024 (no match), absent, and the full `GetFileType` multipart-envelope case.